### PR TITLE
Fix: Prevent deletion error when there are no orphaned documents

### DIFF
--- a/src/Jobs/CSPDocumentCleanupJob.php
+++ b/src/Jobs/CSPDocumentCleanupJob.php
@@ -24,6 +24,13 @@ class CSPDocumentCleanupJob extends AbstractQueuedJob
         $orphanedDocumentIDs    = CSPDocument::get()->filter('CSPViolations.Count()', 0)->column('ID');
         $orphanedDocumentIDList = implode(', ', $orphanedDocumentIDs);
 
+        if (empty($orphanedDocumentIDs)) {
+            $this->addMessage('No orphaned documents to delete.');
+            $this->isComplete = true;
+
+            return;
+        }
+
         $cspDocumentTable = DataObject::getSchema()->baseDataTable(CSPDocument::class);
         SQLDelete::create("\"{$cspDocumentTable}\"")->addWhere(sprintf('"ID" IN (%s)', $orphanedDocumentIDList))->execute();
 


### PR DESCRIPTION
This prevents a blank string being passed into `DELETE FROM "CSPDocument" WHERE ("ID" IN ())` when there are no CSPDocuments to delete.