### PR TITLE
FIX Enforce presence of Queued Jobs module

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ solution combining the best elements of both.
 
 ```sh
 composer require springtimesoft/silverstripe-csp-suite
-composer require symbiote/silverstripe-queuedjobs # Optional but strongly recommended
 ```
 
 This module relies on Queued Jobs to perform regular cleanup tasks. Without a job runner configured, excessive records

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "silverstripe/framework": "^5.2.12",
         "silverstripe/admin": "^2.2",
         "silverstripe/reports": "^5.2",
-        "silverstripeltd/silverstripe-csp": "^2.1"
+        "silverstripeltd/silverstripe-csp": "^2.1",
+        "symbiote/silverstripe-queuedjobs": "^5.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
@@ -23,9 +24,6 @@
     },
     "conflict": {
         "signify-nz/silverstripe-security-headers": "*"
-    },
-    "suggest": {
-        "symbiote/silverstripe-queuedjobs": "Required for regular cleanup of CSP violations."
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Previously this was marked as a suggestion, but the current implementation doesn't check for its presence when defining jobs.

Since the clean-up job is quite critical for avoiding the creation of a black hole in the reports table, I've opted to make the Queued Jobs module mandatory.
