### PR TITLE
Adding new JuicerFragment

### DIFF
--- a/src/Fragments/JuicerFragment.php
+++ b/src/Fragments/JuicerFragment.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Springtimesoft\CSPSuite\Fragments;
+
+use Silverstripe\CSP\Directive;
+use Silverstripe\CSP\Fragments\Fragment;
+use Silverstripe\CSP\Policies\Policy;
+
+/**
+ * Enables usage of Juicer.io within a Content Security Policy.
+ */
+class JuicerFragment implements Fragment
+{
+    public const DOMAIN = '*.juicer.io';
+
+    public static function addTo(Policy $policy): void
+    {
+        $policy
+            ->addDirective(Directive::SCRIPT, self::DOMAIN)
+            ->addDirective(Directive::STYLE, self::DOMAIN)
+            ->addDirective(Directive::IMG, self::DOMAIN)
+            ->addDirective(Directive::FONT, self::DOMAIN)
+            ->addDirective(Directive::CONNECT, self::DOMAIN);
+    }
+}


### PR DESCRIPTION
This is a new fragment to allow the embedding of Juicer.io widgets.

To test you can add this to your HomePage.ss template.
`<div class="juicer-feed" data-feed-id="xxx" data-per="18" data-columns="6" data-interval="0"></div>`
You'll need to add a data-feed-id.
 
Then add this to your HomePageController.php
```
public function index($request)
{
    Requirements::css('https://assets.juicer.io/embed.css');
    Requirements::javascript('https://assets.juicer.io/embed.js');
    return $this;
}
```

On the home page you should now see 6 tiles of the Juicer.io feed and no CSP errors.