### PR TITLE
Add new InstagramFragment.php

### DIFF
--- a/src/Fragments/InstagramFragment.php
+++ b/src/Fragments/InstagramFragment.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Springtimesoft\CSPSuite\Fragments;
+
+use Silverstripe\CSP\Directive;
+use Silverstripe\CSP\Fragments\Fragment;
+use Silverstripe\CSP\Policies\Policy;
+
+/**
+ * Enables usage of Instagram embeds within a Content Security Policy.
+ */
+class InstagramFragment implements Fragment
+{
+    public const DOMAIN = '*.instagram.com';
+
+    public static function addTo(Policy $policy): void
+    {
+        $policy
+            ->addDirective(Directive::SCRIPT, self::DOMAIN)
+            ->addDirective(Directive::FRAME, self::DOMAIN);
+    }
+}


### PR DESCRIPTION
## Description
  This is a new Fragment to allow users to add images from Instagram on their website without it getting blocked by the CSP module



```
$this->addFragments([
        // Allow instagram images to be added to a page
        InstagramFragment::class,
]);
```